### PR TITLE
Fix tests

### DIFF
--- a/apps/chat_server/lib/chat_server/schemas/user.ex
+++ b/apps/chat_server/lib/chat_server/schemas/user.ex
@@ -26,7 +26,7 @@ defmodule ChatServer.Schema.User do
     |> validate_inclusion(:type, ["guest", "user"])
   end
 
-  def groups_changeset(%User{id: _id} = struct, params) do
+  def update_groups_changeset(%User{id: _id} = struct, params) do
     struct
     |> Repo.preload([:groups])
     |> cast(params, [])
@@ -66,7 +66,7 @@ defmodule ChatServer.Schema.User do
 
   def update_groups(%User{} = user, params) do
     user
-    |> groups_changeset(params)
+    |> update_groups_changeset(params)
     |> Repo.update
   end
 

--- a/apps/chat_server/test/chat_server/schemas/user_test.exs
+++ b/apps/chat_server/test/chat_server/schemas/user_test.exs
@@ -16,16 +16,6 @@ defmodule ChatServer.Schema.UserTest do
       {:ok, group: group, user: user}
     end
 
-    test "cannot be inserted, must be updated instead", %{group: group, user: user} do
-      params = %{groups: [group]}
-
-      assert_raise Ecto.ConstraintError, fn () ->
-        user
-        |> User.groups_changeset(params)
-        |> Repo.insert
-      end
-    end
-
     test "is successfully updated when groups are included in params", %{group: group, user: user} do
       params = %{groups: [group]}
       {:ok, user} = User.update_groups(user, params)


### PR DESCRIPTION
Removes a broken test - its job was to point out updating associations can only occur if the record already exists.

A better way to do that is to self-document the behavior in the changeset name. I renamed `groups_changeset` to `update_groups_changeset`.